### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+- **1.0.2**:
+    - Improvement: Blinky peripheral name is now used as the title of the view instead of the default name
+    - Improvement: Empty peripherals view resizes and animates better with orientation change
+    - Improvement: Fixed a minor detail in the (Wireless by Nordic) text at the bottom of the view to avoid situations where it disappears or does not animate properly with orientation changes
+
 - **1.0.1**:
     - Bugfix: Fixed an issue where swiping back from the peripheral view without actually dismissing would cause the app not to reconnect to the Blinky peripheral.
 

--- a/nRFBlinky/Base.lproj/Main.storyboard
+++ b/nRFBlinky/Base.lproj/Main.storyboard
@@ -36,11 +36,10 @@
                     <rect key="frame" x="0.0" y="0.0" width="370" height="27"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="byNordic" translatesAutoresizingMaskIntoConstraints="NO" id="ks6-Eq-dUo">
+                        <imageView opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="byNordic" translatesAutoresizingMaskIntoConstraints="NO" id="ks6-Eq-dUo">
                             <rect key="frame" x="125" y="0.0" width="120" height="11"/>
                         </imageView>
                     </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstItem="g7q-9Z-KkO" firstAttribute="bottom" secondItem="ks6-Eq-dUo" secondAttribute="bottom" constant="16" id="FwJ-Tv-R75"/>
                         <constraint firstItem="ks6-Eq-dUo" firstAttribute="centerX" secondItem="g7q-9Z-KkO" secondAttribute="centerX" id="ocT-RQ-XAP"/>
@@ -142,25 +141,25 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1. Make sure it's switched on." lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bcI-yv-RmI">
-                            <rect key="frame" x="16" y="118" width="193.5" height="17"/>
+                            <rect key="frame" x="18" y="118" width="194" height="17"/>
                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                             <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2. Make sure the coin cell battery has power." lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rmw-BF-cDo">
-                            <rect key="frame" x="16" y="168" width="294.5" height="17"/>
+                            <rect key="frame" x="18" y="168" width="294.5" height="17"/>
                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                             <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Toggle the switch next tot he micro USB port to switch it on." lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IAE-tV-Psp">
-                            <rect key="frame" x="16" y="137" width="316" height="14"/>
+                            <rect key="frame" x="18" y="137" width="316" height="14"/>
                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                             <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If not, connect it to a PC or a charger using a micro USB cable. Coin cell battery is on the bottom side of the dev kit." lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MCd-9i-lIO">
-                            <rect key="frame" x="16" y="187" width="328.5" height="26.5"/>
+                            <rect key="frame" x="18" y="187" width="328.5" height="26.5"/>
                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                             <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -169,21 +168,25 @@
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstItem="bcI-yv-RmI" firstAttribute="top" secondItem="eor-wV-hOm" secondAttribute="bottom" constant="20" id="2Zo-PA-jUm"/>
-                        <constraint firstItem="rmw-BF-cDo" firstAttribute="leading" secondItem="yGS-eH-kQh" secondAttribute="leading" constant="16" id="3od-ce-B9M"/>
+                        <constraint firstItem="bcI-yv-RmI" firstAttribute="centerX" secondItem="yGS-eH-kQh" secondAttribute="centerX" constant="-70" id="3dG-id-lWE"/>
                         <constraint firstItem="eor-wV-hOm" firstAttribute="centerX" secondItem="yGS-eH-kQh" secondAttribute="centerX" id="7Ln-IE-2hw"/>
-                        <constraint firstItem="yGS-eH-kQh" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="rmw-BF-cDo" secondAttribute="trailing" constant="16" id="9yA-0E-HTB"/>
+                        <constraint firstItem="yGS-eH-kQh" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="MCd-9i-lIO" secondAttribute="trailing" constant="10" id="8vP-X7-jbV"/>
                         <constraint firstItem="rmw-BF-cDo" firstAttribute="top" secondItem="IAE-tV-Psp" secondAttribute="bottom" constant="17" id="JQa-k1-PUe"/>
                         <constraint firstItem="IAE-tV-Psp" firstAttribute="top" secondItem="bcI-yv-RmI" secondAttribute="bottom" constant="2" id="KsS-pS-h4D"/>
-                        <constraint firstItem="IAE-tV-Psp" firstAttribute="leading" secondItem="yGS-eH-kQh" secondAttribute="leading" constant="16" id="UrI-BJ-pur"/>
-                        <constraint firstItem="bcI-yv-RmI" firstAttribute="leading" secondItem="yGS-eH-kQh" secondAttribute="leading" constant="16" id="XED-VM-Ebg"/>
-                        <constraint firstItem="yGS-eH-kQh" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="MCd-9i-lIO" secondAttribute="trailing" constant="16" id="aHH-QT-lPN"/>
+                        <constraint firstItem="IAE-tV-Psp" firstAttribute="leading" secondItem="bcI-yv-RmI" secondAttribute="leading" id="Nrq-FZ-QN2"/>
+                        <constraint firstItem="rmw-BF-cDo" firstAttribute="leading" secondItem="bcI-yv-RmI" secondAttribute="leading" id="PCF-YQ-3TX"/>
+                        <constraint firstItem="IAE-tV-Psp" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="yGS-eH-kQh" secondAttribute="leading" constant="10" id="RRu-wh-fv3"/>
+                        <constraint firstItem="yGS-eH-kQh" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bcI-yv-RmI" secondAttribute="trailing" constant="10" id="Xth-gP-EPg"/>
+                        <constraint firstItem="MCd-9i-lIO" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="yGS-eH-kQh" secondAttribute="leading" constant="10" id="ali-6p-WT6"/>
                         <constraint firstItem="MCd-9i-lIO" firstAttribute="top" secondItem="rmw-BF-cDo" secondAttribute="bottom" constant="2" id="c5a-it-7dD"/>
-                        <constraint firstItem="MCd-9i-lIO" firstAttribute="leading" secondItem="yGS-eH-kQh" secondAttribute="leading" constant="16" id="k6z-xE-I4a"/>
+                        <constraint firstItem="bcI-yv-RmI" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="yGS-eH-kQh" secondAttribute="leading" constant="10" id="lGt-8r-YVw"/>
+                        <constraint firstItem="yGS-eH-kQh" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IAE-tV-Psp" secondAttribute="trailing" constant="10" id="ncB-09-Yae"/>
                         <constraint firstItem="0Z5-h0-3hn" firstAttribute="centerX" secondItem="yGS-eH-kQh" secondAttribute="centerX" id="oDu-Dj-pTW"/>
                         <constraint firstItem="eor-wV-hOm" firstAttribute="top" secondItem="0Z5-h0-3hn" secondAttribute="bottom" constant="16" id="oSZ-wu-4Ou"/>
-                        <constraint firstItem="yGS-eH-kQh" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IAE-tV-Psp" secondAttribute="trailing" constant="16" id="wEp-7g-QGq"/>
+                        <constraint firstItem="yGS-eH-kQh" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="rmw-BF-cDo" secondAttribute="trailing" constant="10" id="qrs-18-rm5"/>
+                        <constraint firstItem="rmw-BF-cDo" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="yGS-eH-kQh" secondAttribute="leading" constant="10" id="r1M-vB-NbY"/>
                         <constraint firstItem="0Z5-h0-3hn" firstAttribute="top" secondItem="yGS-eH-kQh" secondAttribute="top" constant="16" id="xfk-qU-tCF"/>
-                        <constraint firstItem="yGS-eH-kQh" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bcI-yv-RmI" secondAttribute="trailing" constant="16" id="zc5-gZ-1Hg"/>
+                        <constraint firstItem="MCd-9i-lIO" firstAttribute="leading" secondItem="bcI-yv-RmI" secondAttribute="leading" id="zy9-1o-Zu8"/>
                     </constraints>
                     <viewLayoutGuide key="safeArea" id="yGS-eH-kQh"/>
                 </view>

--- a/nRFBlinky/Info.plist
+++ b/nRFBlinky/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/nRFBlinky/ViewControllers/BlinkyView/BlinkyViewController.swift
+++ b/nRFBlinky/ViewControllers/BlinkyView/BlinkyViewController.swift
@@ -37,18 +37,20 @@ class BlinkyViewController: UITableViewController, CBCentralManagerDelegate {
     }
     
     public func setPeripheral(_ aPeripheral: BlinkyPeripheral) {
+        let peripheralName = aPeripheral.advertisedName ?? "Unknown Device"
+        title = peripheralName
         blinkyPeripheral = aPeripheral
-        print("Connected to blinky peripheral")
+        print("connecting to blinky")
         centralManager.connect(blinkyPeripheral.basePeripheral, options: nil)
     }
     
     private func handleSwitchValueChange(newValue isOn: Bool){
         if isOn {
             blinkyPeripheral.turnOnLED()
-            ledStateLabel.text = "Turning On"
+            ledStateLabel.text = "ON"
         } else {
             blinkyPeripheral.turnOffLED()
-            ledStateLabel.text = "Turning Off"
+            ledStateLabel.text = "OFF"
         }
     }
     
@@ -63,7 +65,7 @@ class BlinkyViewController: UITableViewController, CBCentralManagerDelegate {
         ledStateLabel.text    = "Reading ..."
         ledToggleSwitch.isEnabled = false
         
-        print("Adding button notification and LED write callback handlers")
+        print("adding button notification and led write callback handlers")
         blinkyPeripheral.setButtonCallback { (isPressed) -> (Void) in
             DispatchQueue.main.async {
                 if isPressed {
@@ -112,7 +114,7 @@ class BlinkyViewController: UITableViewController, CBCentralManagerDelegate {
     }
 
     override func viewDidDisappear(_ animated: Bool) {
-        print("Removing button notification and LED write callback handlers")
+        print("removing button notification and led write callback handlers")
         blinkyPeripheral.removeLEDCallback()
         blinkyPeripheral.removeButtonCallback()
         
@@ -131,14 +133,14 @@ class BlinkyViewController: UITableViewController, CBCentralManagerDelegate {
 
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
         if peripheral == blinkyPeripheral.basePeripheral {
-            print("Connected to blinky.")
+            print("connected to blinky.")
             blinkyPeripheral.discoverBlinkyServices()
         }
     }
 
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
         if peripheral == blinkyPeripheral.basePeripheral {
-            print("Blinky disconnected.")
+            print("blinky disconnected.")
             navigationController?.popToRootViewController(animated: true)
         }
     }

--- a/nRFBlinky/ViewControllers/RootViewController.swift
+++ b/nRFBlinky/ViewControllers/RootViewController.swift
@@ -8,31 +8,36 @@
 
 import UIKit
 
-class RootViewController: UINavigationController, UINavigationControllerDelegate {
+class RootViewController: UINavigationController {
     @IBOutlet var wirelessByNordicView: UIView!
+    
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        delegate = self
         if !view.subviews.contains(wirelessByNordicView) {
             view.addSubview(wirelessByNordicView)
             wirelessByNordicView.frame = CGRect(x: 0, y: (view.frame.height - wirelessByNordicView.frame.size.height), width: view.frame.width, height: wirelessByNordicView.frame.height)
             view.bringSubview(toFront: wirelessByNordicView)
         }
     }
-    
-    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-        UIView.animate(withDuration: 0.05) {
-            self.wirelessByNordicView.alpha = 0
-        }
-    }
-
-    func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
-        UIView.animate(withDuration: 0.05) {
-            self.wirelessByNordicView.alpha = 1
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        self.wirelessByNordicView.alpha = 0
+        if view.subviews.contains(wirelessByNordicView) {
+            coordinator.animateAlongsideTransition(in: self.view, animation: { (context) in
+                self.wirelessByNordicView.alpha = 0
+                self.wirelessByNordicView.frame = CGRect(x: 0,
+                                                         y: (context.containerView.frame.size.height - 27),
+                                                         width: context.containerView.frame.size.width,
+                                                         height: 27)
+            }, completion: { (context) in
+                UIView.animate(withDuration: 0.5, animations: {
+                    self.wirelessByNordicView.alpha = 1
+                })
+            })
         }
     }
 }

--- a/nRFBlinky/ViewControllers/ScannerView/ScannerTableViewController.swift
+++ b/nRFBlinky/ViewControllers/ScannerView/ScannerTableViewController.swift
@@ -32,7 +32,7 @@ class ScannerTableViewController: UITableViewController, CBCentralManagerDelegat
             coordinator.animate(alongsideTransition: { (context) in
                 let width = self.emptyPeripheralsView.frame.size.width
                 let height = self.emptyPeripheralsView.frame.size.height
-                if context.containerView.frame.size.height > context.containerView.frame.size.height {
+                if context.containerView.frame.size.height > context.containerView.frame.size.width {
                     self.emptyPeripheralsView.frame = CGRect(x: 0,
                                                              y: (context.containerView.frame.size.height / 2) - (height / 2),
                                                              width: width,


### PR DESCRIPTION
+Blinky peripheral name is now used as the title of the view instead of the default name
+Improvement: Empty peripherals view resizes and animates better with orientation change
+Improvement: Fixed a minor detail in the (Wireless by Nordic) text at the bottom of the view to avoid situations where it disappears or does not animate properly with orientation changes